### PR TITLE
Fix race condiiton with boides in physics-collider

### DIFF
--- a/src/physics-collider.js
+++ b/src/physics-collider.js
@@ -28,7 +28,7 @@ AFRAME.registerComponent('physics-collider', {
     const uppperMask = 0xFFFF0000
     const lowerMask = 0x0000FFFF
     return function () {
-      if (!this.el.body) return
+      if (!(this.el.body && this.el.body.world)) return
       const currentCollisions = this.currentCollisions
       const thisBodyId = this.el.body.id
       const worldCollisions = this.el.body.world.bodyOverlapKeeper.current


### PR DESCRIPTION
Not 100% clear on why this isn't broken in earleir versions of aframe but on the latest aframe master the initialization order is such that physics-collider seems broken. This same race condition would also happen on any version of aframe though if shape component was used, since the body exists on the element but is not yet added to the world.