### PR TITLE
Update README.md to use newest hand-controls example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Install and use by directly including the [browser files](dist):
       </a-mixin>
     </a-assets>
     <!-- settings pulled in from controller mixin above -->
-    <a-entity hand-controls="left" mixin="controller"></a-entity>
-    <a-entity hand-controls="right" mixin="controller"></a-entity>
+    <a-entity id="leftHand" hand-controls="hand: left; handModelStyle: lowPoly; color: #ffcccc" mixin="controller"></a-entity>
+    <a-entity id="rightHand" hand-controls="hand: right; handModelStyle: lowPoly; color: #ffcccc" mixin="controller"></a-entity>
     <!-- can be picked up because it collides with the hands group and vice versa -->
     <a-entity mixin="cube" position="0 1.6 -1" material="color: red" sleepy
         collision-filter="group: red; collidesWith: default, hands, blue">


### PR DESCRIPTION
Update README.md to use newest hand-controls example, provided at https://github.com/aframevr/aframe/blob/master/docs/components/hand-controls.md

Resolves the following error that occurs when using the example out of the box:

"
"core:a-node:error Failure loading node:   TypeError: Cannot read property 'charAt' of undefined
    at i.update (hand-controls.js:198)
    at initComponent (component.js:330)
    at i.updateProperties (component.js:302)
    at i.module.exports.Component (component.js:78)
    at new i (component.js:662)
    at HTMLElement.initComponent (a-entity.js:332)
    at HTMLElement.updateComponent (a-entity.js:495)
    at HTMLElement.updateComponents (a-entity.js:463)
    at a-entity.js:249
    at a-node.js:127""